### PR TITLE
Resizing and redraw fix

### DIFF
--- a/lib/maps/raster.js
+++ b/lib/maps/raster.js
@@ -29,12 +29,16 @@ const Raster = (props) => {
     })
   }, [])
 
+  // Listen for changes to the viewport dimensions in regl context
   useEffect(() => {
     regl.frame(({ viewportHeight, viewportWidth }) => {
       setDimensions({ viewportHeight, viewportWidth })
     })
   }, [])
 
+  // Ensure that tiles are redrawn when viewport dimensions have changed.
+  // Because the regl dimensions are updated via polling, tiles drawn on
+  // map `render` will use stale dimensions under some race conditions.
   useEffect(() => {
     tiles.current.redraw()
   }, [dimensions.viewportHeight, dimensions.viewportWidth])

--- a/lib/maps/raster.js
+++ b/lib/maps/raster.js
@@ -32,7 +32,16 @@ const Raster = (props) => {
   // Listen for changes to the viewport dimensions in regl context
   useEffect(() => {
     regl.frame(({ viewportHeight, viewportWidth }) => {
-      setDimensions({ viewportHeight, viewportWidth })
+      setDimensions((previousDimensions) => {
+        if (
+          previousDimensions.viewportHeight !== viewportHeight ||
+          previousDimensions.viewportWidth !== viewportWidth
+        ) {
+          return { viewportHeight, viewportWidth }
+        } else {
+          return previousDimensions
+        }
+      })
     })
   }, [])
 
@@ -41,7 +50,7 @@ const Raster = (props) => {
   // map `render` will use stale dimensions under some race conditions.
   useEffect(() => {
     tiles.current.redraw()
-  }, [dimensions.viewportHeight, dimensions.viewportWidth])
+  }, [dimensions])
 
   useEffect(() => {
     tiles.current.updateStyle({ display, opacity, clim })

--- a/lib/maps/raster.js
+++ b/lib/maps/raster.js
@@ -1,4 +1,4 @@
-import { useRef, useEffect } from 'react'
+import { useRef, useEffect, useState } from 'react'
 import { useRegl } from './regl'
 import { useMapbox } from './mapbox'
 import { useControls } from './use-controls'
@@ -11,6 +11,10 @@ const Raster = (props) => {
   const { map } = useMapbox()
   const tiles = useRef()
   const camera = useRef()
+  const [dimensions, setDimensions] = useState({
+    viewportHeight: 0,
+    viewportWidth: 0,
+  })
 
   camera.current = { center: center, zoom: zoom }
 
@@ -24,6 +28,16 @@ const Raster = (props) => {
       tiles.current.draw()
     })
   }, [])
+
+  useEffect(() => {
+    regl.frame(({ viewportHeight, viewportWidth }) => {
+      setDimensions({ viewportHeight, viewportWidth })
+    })
+  }, [])
+
+  useEffect(() => {
+    tiles.current.redraw()
+  }, [dimensions.viewportHeight, dimensions.viewportWidth])
 
   useEffect(() => {
     tiles.current.updateStyle({ display, opacity, clim })

--- a/lib/maps/raster.js
+++ b/lib/maps/raster.js
@@ -31,17 +31,19 @@ const Raster = (props) => {
 
   // Listen for changes to the viewport dimensions in regl context
   useEffect(() => {
-    const frame = regl.frame(({ viewportHeight, viewportWidth }) => {
-      if (
-        dimensions.viewportHeight !== viewportHeight ||
-        dimensions.viewportWidth !== viewportWidth
-      ) {
-        setDimensions({ viewportHeight, viewportWidth })
-      }
+    regl.frame(({ viewportHeight, viewportWidth }) => {
+      setDimensions((previousDimensions) => {
+        if (
+          previousDimensions.viewportHeight !== viewportHeight ||
+          previousDimensions.viewportWidth !== viewportWidth
+        ) {
+          return { viewportHeight, viewportWidth }
+        } else {
+          return previousDimensions
+        }
+      })
     })
-
-    return () => frame.cancel()
-  }, [dimensions])
+  }, [])
 
   // Ensure that tiles are redrawn when viewport dimensions have changed.
   // Because the regl dimensions are updated via polling, tiles drawn on

--- a/lib/maps/raster.js
+++ b/lib/maps/raster.js
@@ -31,19 +31,17 @@ const Raster = (props) => {
 
   // Listen for changes to the viewport dimensions in regl context
   useEffect(() => {
-    regl.frame(({ viewportHeight, viewportWidth }) => {
-      setDimensions((previousDimensions) => {
-        if (
-          previousDimensions.viewportHeight !== viewportHeight ||
-          previousDimensions.viewportWidth !== viewportWidth
-        ) {
-          return { viewportHeight, viewportWidth }
-        } else {
-          return previousDimensions
-        }
-      })
+    const frame = regl.frame(({ viewportHeight, viewportWidth }) => {
+      if (
+        dimensions.viewportHeight !== viewportHeight ||
+        dimensions.viewportWidth !== viewportWidth
+      ) {
+        setDimensions({ viewportHeight, viewportWidth })
+      }
     })
-  }, [])
+
+    return () => frame.cancel()
+  }, [dimensions])
 
   // Ensure that tiles are redrawn when viewport dimensions have changed.
   // Because the regl dimensions are updated via polling, tiles drawn on

--- a/lib/maps/tiles.js
+++ b/lib/maps/tiles.js
@@ -220,6 +220,7 @@ export const createTiles = (regl, opts) => {
               return accum
             }, [])
         )
+        this.renderedTick = this.tick
       } else {
         regl.clear({
           color: [0, 0, 0, 0],
@@ -290,7 +291,6 @@ export const createTiles = (regl, opts) => {
     this.redraw = () => {
       if (this.renderedTick !== this.tick) {
         this.draw()
-        this.renderedTick = this.tick
       }
     }
 


### PR DESCRIPTION
- resolves https://github.com/carbonplan/zarr-webgl-mapbox/issues/6
  - manually track `regl` viewport dimensions in `Raster` and ensure `redraw` is called on any change
- also fixes bug where `redraw` triggered renders already handled by directly `draw`ing