### PR TITLE
Render cached tiles from lower zooms while loading

### DIFF
--- a/lib/maps/tiles.js
+++ b/lib/maps/tiles.js
@@ -238,33 +238,46 @@ export const createTiles = (regl, opts) => {
         return adjusted
       }
 
-      // todo: fix offset adjustment / vertex shader
-      // todo: avoid duplicate renders of the same parent + offset combination
       // todo: refactor helpers
       // todo: handle rendering tiles at _higher_ zooms when cached
 
-      return Object.keys(this.tiles)
+      const adjustedActive = Object.keys(this.tiles)
         .filter((key) => this.active[key])
         .reduce((accum, key) => {
           const keyToRender = getKeyToRender(key)
           const [, , level] = keyToTile(keyToRender)
-          const tile = this.tiles[keyToRender]
           const offsets = this.active[key]
 
           offsets.forEach((offset) => {
-            if (key !== keyToRender) {
-              console.log('switching', {
-                key,
-                keyToRender,
-                offset,
-                adjustedOffset: adjustOffset(offset, level),
-              })
+            const adjustedOffset = adjustOffset(offset, level)
+            if (!accum[keyToRender]) {
+              accum[keyToRender] = []
             }
 
+            const alreadySeenOffset = accum[keyToRender].find(
+              (prev) =>
+                prev[0] === adjustedOffset[0] && prev[1] === adjustedOffset[1]
+            )
+            if (!alreadySeenOffset) {
+              accum[keyToRender].push(adjustedOffset)
+            }
+          })
+
+          return accum
+        }, [])
+
+      return Object.keys(this.tiles)
+        .filter((key) => adjustedActive[key])
+        .reduce((accum, key) => {
+          const [, , level] = keyToTile(key)
+          const tile = this.tiles[key]
+          const offsets = adjustedActive[key]
+
+          offsets.forEach((offset) => {
             accum.push({
               ...tile,
               level,
-              offset: adjustOffset(offset, level),
+              offset,
             })
           })
 
@@ -274,7 +287,6 @@ export const createTiles = (regl, opts) => {
 
     this.draw = () => {
       if (this.display) {
-        console.log({ zoom: this.zoom, level: this.level })
         this.drawTiles(this.getProps())
         this.renderedTick = this.tick
       } else {

--- a/lib/maps/tiles.js
+++ b/lib/maps/tiles.js
@@ -213,7 +213,6 @@ export const createTiles = (regl, opts) => {
         while (z >= 0) {
           const key = tileToKey([x, y, z])
           if (this.tiles[key].cached) {
-            console.log('matching', targetKey === key)
             return key
           }
           z--
@@ -225,21 +224,16 @@ export const createTiles = (regl, opts) => {
         return targetKey
       }
 
-      const adjustOffset = (offset, renderedLevel, key) => {
+      const adjustOffset = (offset, renderedLevel) => {
         const [offsetX, offsetY, level] = offset
         const factor = Math.pow(2, level - renderedLevel)
         const adjusted = [
-          Math.floor(offsetX / factor) * factor,
-          Math.floor(offsetY / factor) * factor,
+          Math.floor(offsetX / factor),
+          Math.floor(offsetY / factor),
         ]
 
-        if (offsetX !== adjusted[0] || offsetY !== adjusted[1]) {
-          console.log({ offset, adjusted, key })
-        }
         return adjusted
       }
-
-      // console.log({ level: this.level, zoom: this.zoom })
 
       // todo: fix offset adjustment / vertex shader
       // todo: avoid duplicate renders of the same parent + offset combination
@@ -255,10 +249,19 @@ export const createTiles = (regl, opts) => {
           const offsets = this.active[key]
 
           offsets.forEach((offset) => {
+            if (key !== keyToRender) {
+              console.log('switching', {
+                key,
+                keyToRender,
+                offset,
+                adjustedOffset: adjustOffset(offset, level),
+              })
+            }
+
             accum.push({
               ...tile,
               level,
-              offset: adjustOffset(offset, level, keyToRender),
+              offset: adjustOffset(offset, level),
             })
           })
 

--- a/lib/maps/tiles.js
+++ b/lib/maps/tiles.js
@@ -144,15 +144,17 @@ export const createTiles = (regl, opts) => {
 	      uniform float pixelRatio;
 	      uniform float zoom;
 	      uniform float size;
+	      uniform float globalLevel;
 	      uniform float level;
 	      uniform vec2 offset;
 	      void main() {
-	        float x = position.x - camera.x * size + offset.x * size;
-	        float y = position.y - camera.y * size + offset.y * size;
 	        float scale = pixelRatio * 512.0 / size;
+	        float globalMagnification = pow(2.0, zoom - globalLevel);
 	        float magnification = pow(2.0, zoom - level);
-	        x = (scale * x * magnification);
-	        y = (scale * y * magnification);
+          float x = magnification * (position.x + offset.x * size) - globalMagnification * camera.x * size ;
+          float y = magnification * (position.y + offset.y * size) - globalMagnification * camera.y * size ;
+	        x = (scale * x);
+	        y = (scale * y);
 	        x = (2.0 * x / viewportWidth);
 	        y = -(2.0 * y / viewportHeight);
 	        ${vertAssignment}
@@ -183,6 +185,7 @@ export const createTiles = (regl, opts) => {
         camera: regl.this('camera'),
         size: regl.this('size'),
         zoom: regl.this('zoom'),
+        globalLevel: regl.this('level'),
         level: regl.prop('level'),
         offset: regl.prop('offset'),
         clim: regl.this('clim'),
@@ -271,6 +274,7 @@ export const createTiles = (regl, opts) => {
 
     this.draw = () => {
       if (this.display) {
+        console.log({ zoom: this.zoom, level: this.level })
         this.drawTiles(this.getProps())
         this.renderedTick = this.tick
       } else {

--- a/lib/maps/tiles.js
+++ b/lib/maps/tiles.js
@@ -209,20 +209,20 @@ export const createTiles = (regl, opts) => {
 
     this.getProps = () => {
       const getKeyToRender = (targetKey) => {
-        let result = targetKey
         let [x, y, z] = keyToTile(targetKey)
         while (z >= 0) {
           const key = tileToKey([x, y, z])
           if (this.tiles[key].cached) {
             console.log('matching', targetKey === key)
-            result = key
+            return key
           }
           z--
           x = Math.floor(x / 2)
           y = Math.floor(y / 2)
         }
 
-        return result
+        // fallback to original key if none are cached
+        return targetKey
       }
 
       const adjustOffset = (offset, renderedLevel, key) => {

--- a/lib/maps/tiles.js
+++ b/lib/maps/tiles.js
@@ -241,10 +241,10 @@ export const createTiles = (regl, opts) => {
 
       // console.log({ level: this.level, zoom: this.zoom })
 
-      // const keysToRender = Object.keys(this.tiles)
-      //   .filter((key) => this.active[key])
-      //   .map(getKeyToRender)
-      //   .filter(Boolean)
+      // todo: fix offset adjustment / vertex shader
+      // todo: avoid duplicate renders of the same parent + offset combination
+      // todo: refactor helpers
+      // todo: handle rendering tiles at _higher_ zooms when cached
 
       return Object.keys(this.tiles)
         .filter((key) => this.active[key])
@@ -252,7 +252,8 @@ export const createTiles = (regl, opts) => {
           const keyToRender = getKeyToRender(key)
           const [, , level] = keyToTile(keyToRender)
           const tile = this.tiles[keyToRender]
-          const offsets = this.active[key] || [] // todo: properly handle parent + offsets
+          const offsets = this.active[key]
+
           offsets.forEach((offset) => {
             accum.push({
               ...tile,

--- a/lib/maps/tiles.js
+++ b/lib/maps/tiles.js
@@ -7,7 +7,8 @@ import {
   pointToCamera,
   pointToTile,
   getSiblings,
-  tileToKey,
+  getKeyToRender,
+  getAdjustedOffset,
 } from './utils'
 
 export const createTiles = (regl, opts) => {
@@ -211,45 +212,17 @@ export const createTiles = (regl, opts) => {
     })
 
     this.getProps = () => {
-      const getKeyToRender = (targetKey) => {
-        let [x, y, z] = keyToTile(targetKey)
-        while (z >= 0) {
-          const key = tileToKey([x, y, z])
-          if (this.tiles[key].cached) {
-            return key
-          }
-          z--
-          x = Math.floor(x / 2)
-          y = Math.floor(y / 2)
-        }
-
-        // fallback to original key if none are cached
-        return targetKey
-      }
-
-      const adjustOffset = (offset, renderedLevel) => {
-        const [offsetX, offsetY, level] = offset
-        const factor = Math.pow(2, level - renderedLevel)
-        const adjusted = [
-          Math.floor(offsetX / factor),
-          Math.floor(offsetY / factor),
-        ]
-
-        return adjusted
-      }
-
-      // todo: refactor helpers
-      // todo: handle rendering tiles at _higher_ zooms when cached
+      // todo: avoid double rendering over same area
 
       const adjustedActive = Object.keys(this.tiles)
         .filter((key) => this.active[key])
         .reduce((accum, key) => {
-          const keyToRender = getKeyToRender(key)
+          const keyToRender = getKeyToRender(key, this.tiles)
           const [, , level] = keyToTile(keyToRender)
           const offsets = this.active[key]
 
           offsets.forEach((offset) => {
-            const adjustedOffset = adjustOffset(offset, level)
+            const adjustedOffset = getAdjustedOffset(offset, level)
             if (!accum[keyToRender]) {
               accum[keyToRender] = []
             }
@@ -266,23 +239,21 @@ export const createTiles = (regl, opts) => {
           return accum
         }, [])
 
-      return Object.keys(this.tiles)
-        .filter((key) => adjustedActive[key])
-        .reduce((accum, key) => {
-          const [, , level] = keyToTile(key)
-          const tile = this.tiles[key]
-          const offsets = adjustedActive[key]
+      return Object.keys(adjustedActive).reduce((accum, key) => {
+        const [, , level] = keyToTile(key)
+        const tile = this.tiles[key]
+        const offsets = adjustedActive[key]
 
-          offsets.forEach((offset) => {
-            accum.push({
-              ...tile,
-              level,
-              offset,
-            })
+        offsets.forEach((offset) => {
+          accum.push({
+            ...tile,
+            level,
+            offset,
           })
+        })
 
-          return accum
-        }, [])
+        return accum
+      }, [])
     }
 
     this.draw = () => {

--- a/lib/maps/tiles.js
+++ b/lib/maps/tiles.js
@@ -7,6 +7,7 @@ import {
   pointToCamera,
   pointToTile,
   getSiblings,
+  tileToKey,
 } from './utils'
 
 export const createTiles = (regl, opts) => {
@@ -182,7 +183,7 @@ export const createTiles = (regl, opts) => {
         camera: regl.this('camera'),
         size: regl.this('size'),
         zoom: regl.this('zoom'),
-        level: regl.this('level'),
+        level: regl.prop('level'),
         offset: regl.prop('offset'),
         clim: regl.this('clim'),
         opacity: regl.this('opacity'),
@@ -206,20 +207,67 @@ export const createTiles = (regl, opts) => {
       primitive: 'points',
     })
 
+    this.getProps = () => {
+      const getKeyToRender = (targetKey) => {
+        let result = targetKey
+        let [x, y, z] = keyToTile(targetKey)
+        while (z >= 0) {
+          const key = tileToKey([x, y, z])
+          if (this.tiles[key].cached) {
+            console.log('matching', targetKey === key)
+            result = key
+          }
+          z--
+          x = Math.floor(x / 2)
+          y = Math.floor(y / 2)
+        }
+
+        return result
+      }
+
+      const adjustOffset = (offset, renderedLevel, key) => {
+        const [offsetX, offsetY, level] = offset
+        const factor = Math.pow(2, level - renderedLevel)
+        const adjusted = [
+          Math.floor(offsetX / factor) * factor,
+          Math.floor(offsetY / factor) * factor,
+        ]
+
+        if (offsetX !== adjusted[0] || offsetY !== adjusted[1]) {
+          console.log({ offset, adjusted, key })
+        }
+        return adjusted
+      }
+
+      // console.log({ level: this.level, zoom: this.zoom })
+
+      // const keysToRender = Object.keys(this.tiles)
+      //   .filter((key) => this.active[key])
+      //   .map(getKeyToRender)
+      //   .filter(Boolean)
+
+      return Object.keys(this.tiles)
+        .filter((key) => this.active[key])
+        .reduce((accum, key) => {
+          const keyToRender = getKeyToRender(key)
+          const [, , level] = keyToTile(keyToRender)
+          const tile = this.tiles[keyToRender]
+          const offsets = this.active[key] || [] // todo: properly handle parent + offsets
+          offsets.forEach((offset) => {
+            accum.push({
+              ...tile,
+              level,
+              offset: adjustOffset(offset, level, keyToRender),
+            })
+          })
+
+          return accum
+        }, [])
+    }
+
     this.draw = () => {
       if (this.display) {
-        this.drawTiles(
-          Object.keys(this.tiles)
-            .filter((key) => this.active[key] && this.tiles[key].ready)
-            .reduce((accum, key) => {
-              const tile = this.tiles[key]
-              this.active[key].forEach(([offsetX, offsetY]) => {
-                accum.push({ ...tile, offset: [offsetX, offsetY] })
-              })
-
-              return accum
-            }, [])
-        )
+        this.drawTiles(this.getProps())
         this.renderedTick = this.tick
       } else {
         regl.clear({

--- a/lib/maps/tiles.js
+++ b/lib/maps/tiles.js
@@ -9,6 +9,7 @@ import {
   getSiblings,
   getKeyToRender,
   getAdjustedOffset,
+  getOverlappingAncestor,
 } from './utils'
 
 export const createTiles = (regl, opts) => {
@@ -212,8 +213,6 @@ export const createTiles = (regl, opts) => {
     })
 
     this.getProps = () => {
-      // todo: avoid double rendering over same area
-
       const adjustedActive = Object.keys(this.tiles)
         .filter((key) => this.active[key])
         .reduce((accum, key) => {
@@ -239,18 +238,22 @@ export const createTiles = (regl, opts) => {
           return accum
         }, [])
 
-      return Object.keys(adjustedActive).reduce((accum, key) => {
-        const [, , level] = keyToTile(key)
-        const tile = this.tiles[key]
-        const offsets = adjustedActive[key]
+      const activeKeys = Object.keys(adjustedActive)
 
-        offsets.forEach((offset) => {
-          accum.push({
-            ...tile,
-            level,
-            offset,
+      return activeKeys.reduce((accum, key) => {
+        if (!getOverlappingAncestor(key, activeKeys)) {
+          const [, , level] = keyToTile(key)
+          const tile = this.tiles[key]
+          const offsets = adjustedActive[key]
+
+          offsets.forEach((offset) => {
+            accum.push({
+              ...tile,
+              level,
+              offset,
+            })
           })
-        })
+        }
 
         return accum
       }, [])

--- a/lib/maps/utils.js
+++ b/lib/maps/utils.js
@@ -69,3 +69,26 @@ export const getSiblings = (tile) => {
     return accum
   }, {})
 }
+
+// todo: handle rendering tiles at _higher_ zooms when cached
+export const getKeyToRender = (targetKey, tiles) => {
+  let [x, y, z] = keyToTile(targetKey)
+  while (z >= 0) {
+    const key = tileToKey([x, y, z])
+    if (tiles[key].cached) {
+      return key
+    }
+    z--
+    x = Math.floor(x / 2)
+    y = Math.floor(y / 2)
+  }
+
+  // fallback to original key if none are cached
+  return targetKey
+}
+
+export const getAdjustedOffset = (offset, renderedLevel) => {
+  const [offsetX, offsetY, level] = offset
+  const factor = Math.pow(2, level - renderedLevel)
+  return [Math.floor(offsetX / factor), Math.floor(offsetY / factor)]
+}

--- a/lib/maps/utils.js
+++ b/lib/maps/utils.js
@@ -55,7 +55,7 @@ export const getSiblings = (tile) => {
     })
   })
 
-  const result = offsets.reduce((accum, offset) => {
+  return offsets.reduce((accum, offset) => {
     const [x, y, z] = offset
     const tile = [clip(x, max), clip(y, max), z]
     const key = tileToKey(tile)
@@ -68,6 +68,4 @@ export const getSiblings = (tile) => {
 
     return accum
   }, {})
-
-  return result
 }

--- a/lib/maps/utils.js
+++ b/lib/maps/utils.js
@@ -87,6 +87,27 @@ export const getKeyToRender = (targetKey, tiles) => {
   return targetKey
 }
 
+export const getOverlappingAncestor = (key, renderedKeys) => {
+  const [aX, aY, aZ] = keyToTile(key)
+  const child = { x: aX, y: aY, z: aZ }
+
+  return renderedKeys.find((parentKey) => {
+    const [bX, bY, bZ] = keyToTile(parentKey)
+    const parent = { x: bX, y: bY, z: bZ }
+
+    if (child.z <= parent.z) {
+      return false
+    } else {
+      const factor = Math.pow(2, child.z - parent.z)
+
+      return (
+        Math.floor(child.x / factor) === parent.x &&
+        Math.floor(child.y / factor) === parent.y
+      )
+    }
+  })
+}
+
 export const getAdjustedOffset = (offset, renderedLevel) => {
   const [offsetX, offsetY, level] = offset
   const factor = Math.pow(2, level - renderedLevel)


### PR DESCRIPTION
This PR renders cached tiles from lower zooms while more granular data is still loading.

A couple of things to note:
- This only smooths the transition when zooming _in_ on unloaded tiles. There's a clear room for improvement here!
- With this change, we're opting to render an ancestor tile in place of _all_ descendent tiles until each one has finished loading. Rendering partial tiles is an investigation worth picking up once we expand support beyond point geometries.