### PR TITLE
Calculate tiles to render based on viewport dimensions

### DIFF
--- a/lib/maps/raster.js
+++ b/lib/maps/raster.js
@@ -16,7 +16,7 @@ const Raster = (props) => {
     viewportWidth: 0,
   })
 
-  camera.current = { center: center, zoom: zoom }
+  camera.current = { center: center, zoom: zoom, viewport: dimensions }
 
   useEffect(() => {
     tiles.current = createTiles(regl, props)

--- a/lib/maps/tiles.js
+++ b/lib/maps/tiles.js
@@ -271,7 +271,7 @@ export const createTiles = (regl, opts) => {
       }
     }
 
-    this.updateCamera = ({ center, zoom }) => {
+    this.updateCamera = ({ center, zoom, viewport }) => {
       const level = zoomToLevel(zoom, this.maxZoom)
       const tile = pointToTile(center.lng, center.lat, level)
       const camera = pointToCamera(center.lng, center.lat, level)
@@ -279,8 +279,14 @@ export const createTiles = (regl, opts) => {
       this.level = level
       this.zoom = zoom
       this.camera = [camera[0], camera[1]]
+      console.log(this.camera)
 
-      this.active = getSiblings(tile)
+      this.active = getSiblings(tile, {
+        viewport,
+        zoom,
+        camera: this.camera,
+        size: this.size,
+      })
 
       Object.keys(this.active).map((key) => {
         if (this.loaders[level]) {

--- a/lib/maps/tiles.js
+++ b/lib/maps/tiles.js
@@ -279,7 +279,6 @@ export const createTiles = (regl, opts) => {
       this.level = level
       this.zoom = zoom
       this.camera = [camera[0], camera[1]]
-      console.log(this.camera)
 
       this.active = getSiblings(tile, {
         viewport,

--- a/lib/maps/utils.js
+++ b/lib/maps/utils.js
@@ -44,30 +44,39 @@ export const zoomToLevel = (zoom, maxZoom) => {
   return Math.max(0, Math.floor(zoom))
 }
 
+const getOffsets = (length, tileSize, camera) => {
+  const siblingCount = (length - tileSize) / tileSize
+
+  // Do not add offset for very small fraction of tile
+  if (Math.abs(siblingCount) < 0.001) {
+    return [0, 0]
+  }
+
+  const cameraOffset = camera - Math.floor(camera)
+  const prev = siblingCount / 2 + 0.5 - cameraOffset
+  const next = siblingCount - prev
+
+  return [-1 * Math.ceil(prev), Math.ceil(next)]
+}
+
 export const getSiblings = (tile, { viewport, zoom, size, camera }) => {
   const [tileX, tileY, tileZ] = tile
   const { viewportHeight, viewportWidth } = viewport
+  const [cameraX, cameraY] = camera
 
   const magnification = Math.pow(2, zoom - tileZ)
   const scale = (window.devicePixelRatio * 512) / size
   const tileSize = size * scale * magnification
 
-  const tileCountX = viewportWidth / tileSize
-  const tileCountY = viewportHeight / tileSize
+  const deltaX = getOffsets(viewportWidth, tileSize, cameraX)
+  const deltaY = getOffsets(viewportHeight, tileSize, cameraY)
 
-  const deltaX = Math.ceil(tileCountX / 2)
-  const deltaY = Math.ceil(tileCountY / 2)
-
-  console.log({ tileSize, viewportWidth, tileCountX })
-  // console.log({ tileCountX, tileCountY })
-  // console.log({ deltaX, deltaY })
   let offsets = []
-  for (let x = deltaX * -1; x <= deltaX; x++) {
-    for (let y = deltaY * -1; y <= deltaY; y++) {
+  for (let x = deltaX[0]; x <= deltaX[1]; x++) {
+    for (let y = deltaY[0]; y <= deltaY[1]; y++) {
       offsets.push([tileX + x, tileY + y, tileZ])
     }
   }
-  // console.log(offsets)
 
   const max = Math.pow(2, tileZ) - 1
   return offsets.reduce((accum, offset) => {

--- a/lib/maps/utils.js
+++ b/lib/maps/utils.js
@@ -44,17 +44,32 @@ export const zoomToLevel = (zoom, maxZoom) => {
   return Math.max(0, Math.floor(zoom))
 }
 
-export const getSiblings = (tile) => {
-  let offsets = []
-  const deltax = [-2, -1, 0, 1, 2]
-  const deltay = [-1, 0, 1]
-  const max = Math.pow(2, tile[2]) - 1
-  deltax.map((x) => {
-    deltay.map((y) => {
-      offsets.push([tile[0] + x, tile[1] + y, tile[2]])
-    })
-  })
+export const getSiblings = (tile, { viewport, zoom, size, camera }) => {
+  const [tileX, tileY, tileZ] = tile
+  const { viewportHeight, viewportWidth } = viewport
 
+  const magnification = Math.pow(2, zoom - tileZ)
+  const scale = (window.devicePixelRatio * 512) / size
+  const tileSize = size * scale * magnification
+
+  const tileCountX = viewportWidth / tileSize
+  const tileCountY = viewportHeight / tileSize
+
+  const deltaX = Math.ceil(tileCountX / 2)
+  const deltaY = Math.ceil(tileCountY / 2)
+
+  console.log({ tileSize, viewportWidth, tileCountX })
+  // console.log({ tileCountX, tileCountY })
+  // console.log({ deltaX, deltaY })
+  let offsets = []
+  for (let x = deltaX * -1; x <= deltaX; x++) {
+    for (let y = deltaY * -1; y <= deltaY; y++) {
+      offsets.push([tileX + x, tileY + y, tileZ])
+    }
+  }
+  // console.log(offsets)
+
+  const max = Math.pow(2, tileZ) - 1
   return offsets.reduce((accum, offset) => {
     const [x, y, z] = offset
     const tile = [clip(x, max), clip(y, max), z]


### PR DESCRIPTION
Uses viewport to calculate minimum set of tiles to draw instead of always rendering fixed 5 by 3 grid around central tile