### PR TITLE
Render cached tiles when loading on zoom out

### DIFF
--- a/lib/maps/tiles.js
+++ b/lib/maps/tiles.js
@@ -218,7 +218,6 @@ export const createTiles = (regl, opts) => {
         .reduce((accum, key) => {
           const keysToRender = getKeysToRender(key, this.tiles, this.maxZoom)
           keysToRender.forEach((keyToRender) => {
-            const [, , level] = keyToTile(keyToRender)
             const offsets = this.active[key]
 
             offsets.forEach((offset) => {

--- a/lib/maps/utils.js
+++ b/lib/maps/utils.js
@@ -74,17 +74,14 @@ export const getKeysToRender = (targetKey, tiles, maxZoom) => {
   const ancestor = getAncestorToRender(targetKey, tiles)
 
   if (ancestor) {
-    console.log('rendering ancestor', { ancestor })
     return [ancestor]
   }
 
   const descendants = getDescendantsToRender(targetKey, tiles, maxZoom)
   if (descendants.length) {
-    console.log('rendering descendants', { targetKey, descendants })
     return descendants
   }
 
-  console.log('fallback', { targetKey })
   return [targetKey]
 }
 


### PR DESCRIPTION
See [test deploy](https://zarr-webgl-mapbox-6xgd81y6x-carbonplan.vercel.app/temperature) which uses `cool` colormap to render cached tiles